### PR TITLE
feature/add endpoint to get user from ring uid

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -21,6 +21,14 @@ class ApiController < ApplicationController
     end
   end
 
+  def userByUid
+    uid  = params[:uid]
+    ring = Ring.find_by! uid: uid
+    user = ring.user
+    response = { status: :ok, user: user }
+    render json: response, status: 200
+  end
+
   def dividends
     start_date = Chronic::parse(params[:from] || '30 days ago')
     end_date   = Chronic::parse(params[:to]   || 'today')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get 'account',                  to: 'dashboard#index', as: 'dashboard'
   get '/auth/:provider/callback', to: 'connections#create'
   get 'api/uid',                  to: 'api#uid'
+  get 'api/userUid',              to: 'api#userUid'
   get 'api/dividends',            to: 'api#dividends'
   get 'api/events',               to: 'api#events'
   get 'graphs/full',              to: 'graphs#full'

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -20,4 +20,24 @@ RSpec.describe ApiController, type: :controller do
       expect(ring.door_accesses.count).to eq 1
     end
   end
+
+  describe 'GET #userByUid' do
+    let(:user) { Fabricate(:user, id: 123, subscription: Fabricate(:subscription, active_until: 30.days.from_now)) }
+    let(:ring) { Fabricate(:ring, user: user, uid: 'foo') }
+
+    it 'does not authorize a non-existing user' do
+      get :userByUid, uid: 'bar'
+      expect(response).to have_http_status(401)
+    end
+
+    it 'authorizes an existing user' do
+      get :userByUid, uid: ring.uid
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the correct user' do
+      get :userByUid, uid: ring.uid
+      expect(response.user.id).to eq 123
+    end
+  end
 end


### PR DESCRIPTION
disclaimer: not a ruby dev so this may not work

The end goal of this PR is to allow another script running on the door pi to take the ring uids that tap in and get that user's twitter name so it can mention them on twitter.
If there's a way to *just* expose the user's twitter id rather than the entire user object that would be far preferable but I don't know ruby or the system that well. Any indication of what to do here would be most welcome!