### PR TITLE
An up-to-date Ration Club event details and description

### DIFF
--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -34,10 +34,11 @@
 .event
   %a.event-title{:href => "https://forms.gle/T3rXorsrb4gXKazv9"} Ration Club
   %br/
-  %div.event-details Wednesdays • 7:00pm – 9:00pm • Lounge
+  %div.event-details Every Wednesday • 7:00pm – 11:00pm • First floor
   %br/
   %a.event-host{:href => "https://bit.ly/edsaperia"} Edward Saperia
-  %p Each week the college hosts a community dinner called Ration Club. It's open to anyone who'd like to find out more about the college and its work.
+  %p Each week the college hosts a community dinner called Ration Club. It's open to anyone who'd like to find out more about the college and its work. 
+  %p The event usually runs until 11 PM and sometimes later, however we recommend arriving between 7 and 8 PM if you want to have food. To enter, ring the doorbell next to the grey door with words 'Newspeak House' above the letter hole on it.
   %a.section-link{:href => "https://forms.gle/T3rXorsrb4gXKazv9"} Register ↗
 
 - if @events.empty?


### PR DESCRIPTION
This PR:
— Makes the actual hours of the event to be up-to-date (I don't remember the event ending before 9 PM)
— Changes "Lounge" to "First floor" (a better description)
— Changes "Wednesdays" to "Every Wednesday" — while slightly longer, it better highlights the recurring nature of the event (someone actually misread Wednesdays as Wednesday and assumed the event was on today). 

Just in case: I didn't test the PR, but I am only changing the markup.