### PR TITLE
Update cohort website link

### DIFF
--- a/app/views/home/study_with_us.html.haml
+++ b/app/views/home/study_with_us.html.haml
@@ -105,7 +105,7 @@
     %li You enjoy meeting new people. Your best work is done in a communal setting in close proximity to others. You go to meetups for fun, perhaps you have organised one. You’re excited by the idea of spending several nights of the week attending events. You have some kind of online presence, and contribute to various online communities. You’re enthusiastic about sharing your knowledge and networks, as well as developing mentoring relationships.
     %li
       You worry as you are reading this that you might not be the kind of person typically found at Newspeak House. We are looking for a diverse, interdisciplinary group that brings a mix of backgrounds, methodologies, fields, and professions — practitioners, organisers, researchers, developers, lawyers, advocates, activists, educators, entrepreneurs, journalists, technology industry actors, field builders, those coming out of a government office or position, policy analysts, public intellectuals, and those whose practice doesn't fit squarely into conventional categories. You can see members of the current cohort
-      %a{:href => "https://2024.newspeak.house"} &thinsp;here
+      %a{:href => "https://2025.newspeak.house"} &thinsp;here
       \.
   
   %p


### PR DESCRIPTION
The 2025 cohort has begun! Let's link to our website instead:

https://2025.newspeak.house/