### PR TITLE
Add one-off Ration Club details for 13 May

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -42,12 +42,31 @@ class ApiController < ApplicationController
       end
     end
 
-    # Add weekly Ration Club (Wednesdays, 7–10pm London time)
-    now_london = Time.zone.now.in_time_zone('Europe/London') 
-    days_until_wed = (3 - now_london.wday) % 7 
-    wednesday = (now_london + days_until_wed.days) 
+    # Add weekly Ration Club (Wednesdays, 7–10pm London time) with a one-off special edition on 2026-05-13.
+    now_london = Time.zone.now.in_time_zone('Europe/London')
+    special_ration_date = Date.new(2026, 5, 13)
 
-    ration_start = wednesday.change(hour: 19, min: 0, sec: 0) 
+    if now_london.to_date <= special_ration_date
+      special_ration_start = now_london.change(
+        year: 2026, month: 5, day: 13, hour: 19, min: 0, sec: 0
+      )
+      special_ration_end = special_ration_start + 3.hours
+
+      cal.event do |e|
+        e.dtstart     = Icalendar::Values::DateTime.new(special_ration_start, tzid: 'Europe/London')
+        e.dtend       = Icalendar::Values::DateTime.new(special_ration_end, tzid: 'Europe/London')
+        e.summary     = "Ration Club - Cohort Reunion ('24 & '25)"
+        e.description = "Register: https://luma.com/vocnx4on\n\nSpecial edition: Ration Club Cohort Reunion ('24 & '25) at Newspeak House."
+        e.location    = 'Newspeak House, 133 Bethnal Green Road, London, E2 7DG, UK'
+        e.url         = 'https://luma.com/vocnx4on'
+      end
+    end
+
+    days_until_wed = (3 - now_london.wday) % 7
+    wednesday = (now_london + days_until_wed.days)
+    wednesday += 7.days if wednesday.to_date <= special_ration_date
+
+    ration_start = wednesday.change(hour: 19, min: 0, sec: 0)
     ration_end = ration_start + 3.hours
 
     cal.event do |e|

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -31,14 +31,24 @@
 
 %h2 What's On
 
+- special_ration_club_date = Date.new(2026, 5, 13)
+- show_special_ration_club = Time.zone.today <= special_ration_club_date
+- ration_club_link = show_special_ration_club ? "https://luma.com/vocnx4on" : "https://forms.gle/T3rXorsrb4gXKazv9"
+- ration_club_details = show_special_ration_club ? "Wednesday 13 May • 7:00pm – 10:00pm • Lounge" : "Wednesdays • 7:00pm – 10:00pm • Lounge"
+- ration_club_description = if show_special_ration_club
+  "Special edition: Ration Club Cohort Reunion ('24 & '25). Join us at Newspeak House on Wednesday 13 May for a cross-cohort evening with activities, trivia, and dinner."
+else
+  "Each week the college hosts a community dinner called Ration Club. It's open to anyone who'd like to find out more about the college and its work."
+end
+
 .event
-  %a.event-title{:href => "https://forms.gle/T3rXorsrb4gXKazv9"} Ration Club
+  %a.event-title{:href => ration_club_link} Ration Club
   %br/
-  %div.event-details Wednesdays • 7:00pm – 10:00pm • Lounge
+  %div.event-details= ration_club_details
   %br/
   %a.event-host{:href => "https://bit.ly/edsaperia"} Edward Saperia
-  %p Each week the college hosts a community dinner called Ration Club. It's open to anyone who'd like to find out more about the college and its work.
-  %a.section-link{:href => "https://forms.gle/T3rXorsrb4gXKazv9"} Register ↗
+  %p= ration_club_description
+  %a.section-link{:href => ration_club_link} Register ↗
 
 - if @events.empty?
   .archive-empty Nothing at the moment!

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -43,11 +43,20 @@
 
 %h3#events What's On
 %div.wide-pic{:style => "background-image: url(#{image_path "techforgood.jpg"})"}
+- special_ration_club_date = Date.new(2026, 5, 13)
+- show_special_ration_club = Time.zone.today <= special_ration_club_date
+- ration_club_link = show_special_ration_club ? "https://luma.com/vocnx4on" : "https://forms.gle/T3rXorsrb4gXKazv9"
+- ration_club_details = show_special_ration_club ? "Wednesday 13 May • 7:00pm – 10:00pm • Lounge" : "Wednesdays • 7:00pm – 10:00pm • Lounge"
+- ration_club_description = if show_special_ration_club
+  "Special edition: Ration Club Cohort Reunion ('24 & '25). Join us at Newspeak House on Wednesday 13 May for a cross-cohort evening with activities, trivia, and dinner."
+else
+  "Each week the college hosts a community dinner called Ration Club. It's open to anyone who'd like to find out more about the college and its work. To find out more or if you'd like to attend, please register."
+end
 .events-toc
   %ul
     %li
       %a{:href => "#event-ration-club"}
-        %span.toc-event-details Wednesdays • 7:00pm – 10:00pm • Lounge
+        %span.toc-event-details= ration_club_details
         %span.toc-event-title Ration Club
     - @events.each do |event|
       %li
@@ -57,13 +66,13 @@
 
 %h3 Event Details
 .event{ id: "event-ration-club" }
-  %a.event-title{:href => "https://forms.gle/T3rXorsrb4gXKazv9"} Ration Club
+  %a.event-title{:href => ration_club_link} Ration Club
   %br/
-  %div.event-details Wednesdays • 7:00pm – 10:00pm • Lounge
+  %div.event-details= ration_club_details
   %br/
   %a.event-host{:href => "https://bit.ly/edsaperia"} Edward Saperia
-  %p Each week the college hosts a community dinner called Ration Club. It's open to anyone who'd like to find out more about the college and its work. To find out more or if you'd like to attend, please register.
-  %a.section-link{:href => "https://forms.gle/T3rXorsrb4gXKazv9"} Register ↗
+  %p= ration_club_description
+  %a.section-link{:href => ration_club_link} Register ↗
 
 - @events.each do |event|
   = render partial: 'events/row', locals: { event: event }


### PR DESCRIPTION
## Summary
- show a one-off Ration Club special-event link/details for Wednesday 13 May on the home and events pages
- keep regular weekly Ration Club copy and registration link for dates after 13 May
- add a one-off May 13 iCal entry using the Luma URL and keep weekly recurring entries starting from the following Wednesday

## Test plan
- [ ] Open `/` and confirm Ration Club links to `https://luma.com/vocnx4on` before/on 13 May
- [ ] Open `/events` and confirm the same one-off Ration Club details and link
- [ ] Check `/api/events.ics` and confirm one-off 13 May Ration Club event points to Luma
- [ ] Confirm weekly Ration Club entry remains in `.ics` for subsequent Wednesdays

Made with [Cursor](https://cursor.com)